### PR TITLE
 Fixes for deprecated functions

### DIFF
--- a/TypeScriptCodeHints/main.js
+++ b/TypeScriptCodeHints/main.js
@@ -26,12 +26,12 @@
 /*global define, brackets, $, window */
 
 define(function (require, exports, module) {
-	"use strict";
+  "use strict";
 
-	var AppInit           = brackets.getModule("utils/AppInit"),
-		CodeHintManager   = brackets.getModule("editor/CodeHintManager"),
+  var AppInit             = brackets.getModule("utils/AppInit"),
+        CodeHintManager   = brackets.getModule("editor/CodeHintManager"),
         Async             = brackets.getModule("utils/Async"),
-        StringUtils       = brackets.getModule("utils/StringUtils"),
+        _                 = brackets.getModule("thirdparty/lodash"),
         TypeScriptUtils   = require("TypeScript/main").TypeScriptUtils,
         TypeScriptService = require("TypeScript/main").TypeScriptService;
     
@@ -196,9 +196,9 @@ define(function (require, exports, module) {
 
                 // highlight the matched portion of each hint
                 if (index >= 0) {
-                    var prefix  = StringUtils.htmlEscape(hint.slice(0, index)),
-                        match   = StringUtils.htmlEscape(hint.slice(index, index + query.length)),
-                        suffix  = StringUtils.htmlEscape(hint.slice(index + query.length));
+                    var prefix  = _.escape(hint.slice(0, index)),
+                        match   = _.escape(hint.slice(index, index + query.length)),
+                        suffix  = _.escape(hint.slice(index + query.length));
 
                     $hintObj.append(delimiter + prefix)
                         .append($('<span>')

--- a/TypeScriptCodeHints/unittests.js
+++ b/TypeScriptCodeHints/unittests.js
@@ -29,9 +29,9 @@ define(function (require, exports, module) {
     "use strict";
 
     var Editor              = brackets.getModule("editor/Editor").Editor,
-        EditorManager       = brackets.getModule("editor/EditorManager"),
         FileUtils           = brackets.getModule("file/FileUtils"),
         DocumentManager     = brackets.getModule("document/DocumentManager"),
+        MainViewManager     = brackets.getModule("view/MainViewManager"),
         SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils"),
         UnitTestReporter    = brackets.getModule("test/UnitTestReporter"),
         TypeScriptCodeHints = require("TypeScriptCodeHints/main");
@@ -51,8 +51,7 @@ define(function (require, exports, module) {
         
         // Initialize EditorManager
         var $editorHolder = $("<div id='mock-editor-holder'/>");
-        EditorManager.setEditorHolder($editorHolder);
-        EditorManager._init();
+        MainViewManager._initialize($editorHolder);
         $("body").append($editorHolder);
         
         // create Editor instance

--- a/TypeScriptQuickEdit/main.js
+++ b/TypeScriptQuickEdit/main.js
@@ -30,10 +30,8 @@ define(function (require, exports, module) {
     
     var AppInit                 = brackets.getModule("utils/AppInit"),
         MultiRangeInlineEditor  = brackets.getModule("editor/MultiRangeInlineEditor").MultiRangeInlineEditor,
-        FileIndexManager        = brackets.getModule("project/FileIndexManager"),
         EditorManager           = brackets.getModule("editor/EditorManager"),
         DocumentManager         = brackets.getModule("document/DocumentManager"),
-        NativeFileSystem        = brackets.getModule("file/NativeFileSystem").NativeFileSystem,
         FileUtils               = brackets.getModule("file/FileUtils"),
         Async                   = brackets.getModule("utils/Async"),
         TypeScriptUtils         = require("TypeScript/main").TypeScriptUtils,

--- a/TypeScriptQuickEdit/unittests.js
+++ b/TypeScriptQuickEdit/unittests.js
@@ -30,12 +30,10 @@ define(function (require, exports, module) {
 
     var CommandManager,         // loaded from brackets.test
         EditorManager,          // loaded from brackets.test
-        FileIndexManager,       // loaded from brackets.test
         PerfUtils,              // loaded from brackets.test
         JSUtils,                // loaded from brackets.test
         
         FileUtils           = brackets.getModule("file/FileUtils"),
-        NativeFileSystem    = brackets.getModule("file/NativeFileSystem").NativeFileSystem,
         SpecRunnerUtils     = brackets.getModule("spec/SpecRunnerUtils"),
         UnitTestReporter    = brackets.getModule("test/UnitTestReporter"),
         TypeScriptQuickEdit = require("TypeScriptQuickEdit/main");
@@ -160,7 +158,6 @@ define(function (require, exports, module) {
                     testWindow          = w;
                     EditorManager       = testWindow.brackets.test.EditorManager;
                     CommandManager      = testWindow.brackets.test.CommandManager;
-                    FileIndexManager    = testWindow.brackets.test.FileIndexManager;
                     JSUtils             = testWindow.brackets.test.JSUtils;
                 });
                 


### PR DESCRIPTION
This fixes #13 and fixes #10, though the latter is going solely by the comments made in the issue. This might also solve #12, but I am unsure (if it does, it means your unit tests now work with SplitView).

I figured I'd make these changes as they comprise the majority of the incompatibility this extension has with the newest versions of Brackets, and gives the next person who wants to help fix this a few less things to do. :)
